### PR TITLE
[Feature] fab -> '쿠폰 등록하기' 선택 시 갤러리 이동

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application
         android:name=".BuddyConApplication"
         android:allowBackup="true"

--- a/presentation/src/main/java/com/yapp/buddycon/presentation/ui/addCoupon/AddCouponActivity.kt
+++ b/presentation/src/main/java/com/yapp/buddycon/presentation/ui/addCoupon/AddCouponActivity.kt
@@ -1,15 +1,33 @@
 package com.yapp.buddycon.presentation.ui.addCoupon
 
+import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import com.yapp.buddycon.presentation.R
 import com.yapp.buddycon.presentation.base.BaseActivity
 import com.yapp.buddycon.presentation.databinding.ActivityAddCouponBinding
-import com.yapp.buddycon.presentation.databinding.ActivityBuddyConBinding
 
 class AddCouponActivity : BaseActivity<ActivityAddCouponBinding>(R.layout.activity_add_coupon) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        init()
+    }
+
+    private fun init() {
+        setAppbar()
+        getImageUri()
+    }
+
+    private fun getImageUri() {
+        val imgUri = intent.getParcelableExtra<Uri>("imageUri")
+        Log.e("AppTest", "AddCouponActivity/ imgUri : $imgUri")
+
+        binding.shivCoupon.setImageURI(imgUri) // 현재 테스트용으로 전달받은 이미지 uri로 이미지뷰에 보여주고 있음
+    }
+
+    private fun setAppbar() {
         binding.appbarAddCoupon.ibnAppbarBack.setOnClickListener { finish() }
     }
 }

--- a/presentation/src/main/java/com/yapp/buddycon/presentation/ui/main/BuddyConActivity.kt
+++ b/presentation/src/main/java/com/yapp/buddycon/presentation/ui/main/BuddyConActivity.kt
@@ -1,12 +1,16 @@
 package com.yapp.buddycon.presentation.ui.main
 
+import android.Manifest
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.snackbar.Snackbar
 import com.yapp.buddycon.presentation.R
 import com.yapp.buddycon.presentation.base.BaseActivity
 import com.yapp.buddycon.presentation.databinding.ActivityBuddyConBinding
@@ -15,14 +19,19 @@ import com.yapp.buddycon.presentation.ui.makeCoupon.MakeCouponActivity
 
 class BuddyConActivity : BaseActivity<ActivityBuddyConBinding>(R.layout.activity_buddy_con) {
 
-    private val buddyViewModel : BuddyConViewModel by viewModels()
+    private val buddyViewModel: BuddyConViewModel by viewModels()
+
+    private lateinit var type: String // String 변수로 임시 설정 -> 추후 enum으로 변경 예정
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.buddyViewModel = buddyViewModel
 
-        binding.tvAddCoupon.setOnClickListener { startActivity(Intent(this,AddCouponActivity::class.java)) }
-        binding.tvMakeCoupon.setOnClickListener { startActivity(Intent(this,MakeCouponActivity::class.java))}
+        initGallery()
+
+        binding.tvMakeCoupon.setOnClickListener {
+            startActivity(Intent(this, MakeCouponActivity::class.java))
+        }
 
         initToolbar()
         initNavigation()
@@ -34,20 +43,66 @@ class BuddyConActivity : BaseActivity<ActivityBuddyConBinding>(R.layout.activity
         return true
     }
 
-    private fun initToolbar(){
+    private fun initToolbar() {
         setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayShowTitleEnabled(false)
     }
 
-    private fun initNavigation(){
-        val navHostFragment = supportFragmentManager.findFragmentById(R.id.fragment_container_view) as NavHostFragment
+    private fun initNavigation() {
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.fragment_container_view) as NavHostFragment
         val navController = navHostFragment.navController
-        val appBarConfiguration = AppBarConfiguration(setOf(
-            R.id.firstFragment,
-            R.id.secondFragment,
-            R.id.thirdFragment
-        ))
+        val appBarConfiguration = AppBarConfiguration(
+            setOf(
+                R.id.firstFragment,
+                R.id.secondFragment,
+                R.id.thirdFragment
+            )
+        )
         binding.toolbar.setupWithNavController(navController, appBarConfiguration)
         binding.bottomNavigationView.setupWithNavController(navController)
+    }
+
+    private fun initGallery() { // 불필요 주석은 추후 제거 예정
+        val getImageContent =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+                if (it.resultCode == RESULT_OK) {
+                    Log.d("AppTest", "data : ${it.data}")
+                    //binding.ivPhoto.setImageURI(it.data?.data)
+                    Snackbar.make(binding.root, "사진을 불러왔습니다", Snackbar.LENGTH_SHORT).show()
+                    when (type) {
+                        "add" -> { // 등록
+                            val intent = Intent(this, AddCouponActivity::class.java)
+                            it.data?.let { galleryIntent ->
+                                galleryIntent.data?.let { uri ->
+                                    intent.putExtra("imageUri", uri)
+                                    startActivity(intent)
+                                }
+                            }
+                        }
+                        "make" -> {} // 제작
+                    }
+                }
+            }
+
+        val requestPermissionLauncher =
+            registerForActivityResult(
+                ActivityResultContracts.RequestPermission()
+            ) { isGranted: Boolean ->
+                if (isGranted) {
+                    Log.e("AppTest", "권한 승인 ok")
+                    val intent = Intent(Intent.ACTION_PICK) // 갤러리관련 앱
+                    //val intent = Intent(Intent.ACTION_GET_CONTENT)  // 전체 이미지 관련 파일 선택 가능한 화면으로 이동
+                    intent.type = "image/*"
+                    getImageContent.launch(Intent.createChooser(intent, "Chooser Test"))
+                } else {
+                    Snackbar.make(binding.root, "권한이 승인되지 않았습니다", Snackbar.LENGTH_SHORT).show()
+                }
+            }
+
+        binding.tvAddCoupon.setOnClickListener { // '쿠폰 등록하기' 선택 시
+            this.type = "add" //
+            requestPermissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
     }
 }

--- a/presentation/src/main/java/com/yapp/buddycon/presentation/ui/main/BuddyConActivity.kt
+++ b/presentation/src/main/java/com/yapp/buddycon/presentation/ui/main/BuddyConActivity.kt
@@ -16,27 +16,24 @@ import com.yapp.buddycon.presentation.base.BaseActivity
 import com.yapp.buddycon.presentation.databinding.ActivityBuddyConBinding
 import com.yapp.buddycon.presentation.ui.addCoupon.AddCouponActivity
 import com.yapp.buddycon.presentation.ui.makeCoupon.MakeCouponActivity
+import timber.log.Timber
 
 class BuddyConActivity : BaseActivity<ActivityBuddyConBinding>(R.layout.activity_buddy_con) {
 
     private val buddyViewModel: BuddyConViewModel by viewModels()
 
-    private lateinit var type: String // String 변수로 임시 설정 -> 추후 enum으로 변경 예정
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.buddyViewModel = buddyViewModel
-
-        initGallery()
 
         binding.tvMakeCoupon.setOnClickListener {
             startActivity(Intent(this, MakeCouponActivity::class.java))
         }
 
+        initForAddCoupon()
         initToolbar()
         initNavigation()
     }
-
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.menu_buddycon, menu)
@@ -63,24 +60,18 @@ class BuddyConActivity : BaseActivity<ActivityBuddyConBinding>(R.layout.activity
         binding.bottomNavigationView.setupWithNavController(navController)
     }
 
-    private fun initGallery() { // 불필요 주석은 추후 제거 예정
+    private fun initForAddCoupon() { // 불필요 주석은 추후 제거 예정
         val getImageContent =
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
                 if (it.resultCode == RESULT_OK) {
-                    Log.d("AppTest", "data : ${it.data}")
-                    //binding.ivPhoto.setImageURI(it.data?.data)
-                    Snackbar.make(binding.root, "사진을 불러왔습니다", Snackbar.LENGTH_SHORT).show()
-                    when (type) {
-                        "add" -> { // 등록
-                            val intent = Intent(this, AddCouponActivity::class.java)
-                            it.data?.let { galleryIntent ->
-                                galleryIntent.data?.let { uri ->
-                                    intent.putExtra("imageUri", uri)
-                                    startActivity(intent)
-                                }
-                            }
+                    //Snackbar.make(binding.root, "사진을 불러왔습니다", Snackbar.LENGTH_SHORT).show()
+
+                    val intent = Intent(this, AddCouponActivity::class.java)
+                    it.data?.let { galleryIntent ->
+                        galleryIntent.data?.let { uri ->
+                            intent.putExtra("imageUri", uri)
+                            startActivity(intent)
                         }
-                        "make" -> {} // 제작
                     }
                 }
             }
@@ -90,7 +81,8 @@ class BuddyConActivity : BaseActivity<ActivityBuddyConBinding>(R.layout.activity
                 ActivityResultContracts.RequestPermission()
             ) { isGranted: Boolean ->
                 if (isGranted) {
-                    Log.e("AppTest", "권한 승인 ok")
+                    Timber.tag("AppTest").e("권한 승인 ok")
+
                     val intent = Intent(Intent.ACTION_PICK) // 갤러리관련 앱
                     //val intent = Intent(Intent.ACTION_GET_CONTENT)  // 전체 이미지 관련 파일 선택 가능한 화면으로 이동
                     intent.type = "image/*"
@@ -100,8 +92,8 @@ class BuddyConActivity : BaseActivity<ActivityBuddyConBinding>(R.layout.activity
                 }
             }
 
-        binding.tvAddCoupon.setOnClickListener { // '쿠폰 등록하기' 선택 시
-            this.type = "add" //
+        // '쿠폰 등록하기' 선택 시
+        binding.tvAddCoupon.setOnClickListener {
             requestPermissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
         }
     }

--- a/presentation/src/main/res/layout/activity_add_coupon.xml
+++ b/presentation/src/main/res/layout/activity_add_coupon.xml
@@ -13,10 +13,22 @@
         <include
             android:id="@+id/appbar_add_coupon"
             layout="@layout/layout_appbar"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:title="@{@string/add_coupon_giftcon}"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:title="@{@string/add_coupon_giftcon}" />
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/shiv_coupon"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="24dp"
+            android:elevation="1dp"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/appbar_add_coupon"
+            app:layout_constraintWidth_percent="0.91" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 무슨 기능인가요?
쿠폰 등록을 위해 이미지 고르기

## 화면

<img src="https://user-images.githubusercontent.com/69443895/211193501-29024e86-f718-4d45-a211-c1d8035b0898.png" width="200" height="450"/> <img src="https://user-images.githubusercontent.com/69443895/211193631-7b757531-8d99-44ea-b2a2-9643209fcb8f.png" width="200" height="450"/>



## 구체적인 작업 내용
- fab -> '쿠폰 등록하기' 선택 시 갤러리 이동
- 이미지 선택 시 AddCouponActivity 로 이동
- 선택한 이미지 uri 전달 받고 이미지뷰에 나타나는 것 확인

## 기타
- 추후 바코드 api 와 연동 예정

## Close Issue
Close #
