### PR TITLE
[Feature] 쿠폰 등록용 이미지의 바코드 유무 처리 기능

### DIFF
--- a/buildSrc/src/main/java/Dependency.kt
+++ b/buildSrc/src/main/java/Dependency.kt
@@ -101,5 +101,9 @@ object ModuleDependency {
     object KaKao{
         const val LOGIN = "com.kakao.sdk:v2-user:${Versions.KAKAO_LOGIN}"
     }
+
+    object MLkit {
+        const val ML_Kit = "com.google.mlkit:barcode-scanning:${Versions.ML_KIT}"
+    }
 }
 

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -67,4 +67,5 @@ dependencies {
     implementation(ModuleDependency.Hilt.HILT)
     kapt(ModuleDependency.Hilt.HILT_COMPILER)
     implementation(ModuleDependency.KaKao.LOGIN)
+    implementation(ModuleDependency.MLkit.ML_Kit)
 }

--- a/presentation/src/main/java/com/yapp/buddycon/presentation/base/BaseDialogFragment.kt
+++ b/presentation/src/main/java/com/yapp/buddycon/presentation/base/BaseDialogFragment.kt
@@ -1,0 +1,42 @@
+package com.yapp.buddycon.presentation.base
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.DialogFragment
+
+abstract class BaseDialogFragment<T : ViewDataBinding>(@LayoutRes private val layoutResId: Int) :
+    DialogFragment() {
+
+    protected var _binding: T? = null
+    val binding: T
+        get() = _binding ?: throw IllegalStateException("_binding is not initialized !")
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        isCancelable = false
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = DataBindingUtil.inflate(inflater, layoutResId, container, false)
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setEvent()
+    }
+
+    open fun setEvent() {}
+}

--- a/presentation/src/main/java/com/yapp/buddycon/presentation/ui/addCoupon/AddCouponActivity.kt
+++ b/presentation/src/main/java/com/yapp/buddycon/presentation/ui/addCoupon/AddCouponActivity.kt
@@ -2,7 +2,6 @@ package com.yapp.buddycon.presentation.ui.addCoupon
 
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.common.InputImage
 import com.yapp.buddycon.presentation.R
@@ -44,6 +43,12 @@ class AddCouponActivity : BaseActivity<ActivityAddCouponBinding>(R.layout.activi
                         }
                     } else {
                         Timber.tag(TAG).e("read image success but no barcode")
+                        MessageDialogFragment("바코드 인식 오류 \n이미지를 다시 선택해주세요") {
+                            finish()
+                        }.show(
+                            supportFragmentManager,
+                            null
+                        )
                     }
                 }.addOnFailureListener {
                     Timber.tag(TAG).e("read image fail")

--- a/presentation/src/main/java/com/yapp/buddycon/presentation/ui/addCoupon/AddCouponActivity.kt
+++ b/presentation/src/main/java/com/yapp/buddycon/presentation/ui/addCoupon/AddCouponActivity.kt
@@ -3,11 +3,16 @@ package com.yapp.buddycon.presentation.ui.addCoupon
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.common.InputImage
 import com.yapp.buddycon.presentation.R
 import com.yapp.buddycon.presentation.base.BaseActivity
 import com.yapp.buddycon.presentation.databinding.ActivityAddCouponBinding
+import timber.log.Timber
 
 class AddCouponActivity : BaseActivity<ActivityAddCouponBinding>(R.layout.activity_add_coupon) {
+
+    private val TAG = "AppTest"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -17,14 +22,33 @@ class AddCouponActivity : BaseActivity<ActivityAddCouponBinding>(R.layout.activi
 
     private fun init() {
         setAppbar()
-        getImageUri()
+        getBarcodeNumber()
     }
 
-    private fun getImageUri() {
-        val imgUri = intent.getParcelableExtra<Uri>("imageUri")
-        Log.e("AppTest", "AddCouponActivity/ imgUri : $imgUri")
+    private fun getBarcodeNumber() {
+        val imageUri = intent.getParcelableExtra<Uri>("imageUri")
+        Timber.tag(TAG).e("AddCouponActivity/ imgUri : %s", imageUri)
+        binding.shivCoupon.setImageURI(imageUri)// 현재 테스트용으로 전달받은 이미지 uri로 이미지뷰에 보여주고 있음
 
-        binding.shivCoupon.setImageURI(imgUri) // 현재 테스트용으로 전달받은 이미지 uri로 이미지뷰에 보여주고 있음
+        imageUri?.let { uri ->
+            val barcodeScanner = BarcodeScanning.getClient()
+            val inputImage = InputImage.fromFilePath(this, uri)
+
+            barcodeScanner.process(inputImage)
+                .addOnSuccessListener { barcodes ->
+                    Timber.tag(TAG).e("barcode list size : %s", barcodes.size.toString())
+                    if (barcodes.size >= 1) {
+                        barcodes[0]?.let { barcode ->
+                            val barcodeNumber = barcode.rawValue
+                            Timber.tag(TAG).e("barcode number : %s", barcodeNumber)
+                        }
+                    } else {
+                        Timber.tag(TAG).e("read image success but no barcode")
+                    }
+                }.addOnFailureListener {
+                    Timber.tag(TAG).e("read image fail")
+                }
+        }
     }
 
     private fun setAppbar() {

--- a/presentation/src/main/java/com/yapp/buddycon/presentation/ui/addCoupon/MessageDialogFragment.kt
+++ b/presentation/src/main/java/com/yapp/buddycon/presentation/ui/addCoupon/MessageDialogFragment.kt
@@ -1,0 +1,28 @@
+package com.yapp.buddycon.presentation.ui.addCoupon
+
+import android.os.Bundle
+import android.view.View
+import com.yapp.buddycon.presentation.R
+import com.yapp.buddycon.presentation.base.BaseDialogFragment
+import com.yapp.buddycon.presentation.databinding.DialogMessageBinding
+
+// 메세지와 '확인' 버튼 하나만 있는 다이얼로그
+class MessageDialogFragment(
+    private val message: String,
+    private val onConfirmListener: (() -> Unit)? = null
+) : BaseDialogFragment<DialogMessageBinding>(R.layout.dialog_message) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.message = message
+    }
+
+    override fun setEvent() {
+        super.setEvent()
+
+        binding.tvConfirm.setOnClickListener {
+            onConfirmListener?.invoke()
+            dismiss()
+        }
+    }
+}

--- a/presentation/src/main/res/drawable/bg_message_dialog.xml
+++ b/presentation/src/main/res/drawable/bg_message_dialog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <solid android:color="@color/white" />
+</shape>

--- a/presentation/src/main/res/layout/activity_add_coupon.xml
+++ b/presentation/src/main/res/layout/activity_add_coupon.xml
@@ -24,6 +24,7 @@
             android:layout_height="0dp"
             android:layout_marginTop="24dp"
             android:elevation="1dp"
+            android:scaleType="center"
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/presentation/src/main/res/layout/dialog_message.xml
+++ b/presentation/src/main/res/layout/dialog_message.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="message"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="312dp"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_message_dialog"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            >
+
+            <TextView
+                android:id="@+id/tv_message"
+                style="@style/bold18"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="24dp"
+                android:gravity="left"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="쿠폰 이름을 입력해 주세요"
+                android:text="@{message}"/>
+
+            <TextView
+                android:id="@+id/tv_confirm"
+                style="@style/bold14.skyblue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="40dp"
+                android:layout_marginBottom="32dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_message"
+                tools:text="확인"
+                android:text="@string/confirm_dialog"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="common_make_coupon">제작티콘 만들기</string>
     <string name="add_coupon_giftcon">기프티콘 등록하기</string>
     <string name="add_coupon_makecon">제작티콘 등록하기</string>
+    <string name="confirm_dialog">확인</string>
 </resources>

--- a/presentation/src/main/res/values/text_style.xml
+++ b/presentation/src/main/res/values/text_style.xml
@@ -41,6 +41,10 @@
         <item name="android:letterSpacing">-0.02</item>
         <item name="android:lineSpacingMultiplier">1.4</item>
     </style>
+    
+    <style name="bold14.skyblue" parent="bold14">
+        <item name="android:textColor">@color/skyblue</item>
+    </style>
 
     <style name="bold12">
         <item name="fontFamily">@font/pretendard_bold</item>


### PR DESCRIPTION
## 무슨 기능인가요?
- 쿠폰 등록 시 갤러리에서 선택한 이미지에 바코드가 있는지를 판단
- 바코드 인식이 안되는 경우 다이얼로그 나타냄
   - '확인' 누르면 이전화면으로 돌아가짐

## 화면
<img src="https://user-images.githubusercontent.com/69443895/212531493-d4fc23e2-c8d5-4cd4-8073-7c84727b9916.png" width="200" height="450"/>

## 구체적인 작업 내용
- BaseDialogFrament 추가
   - 필요한 부분 추가 논의 후 수정해볼 수 있을 것 같습니다
- Goolge ML Kit 적용

## 기타
- Dialog 나타낼 시 width는 실행 기기의 가로 대비 비율로 설정하는 것 고려해보기

## Close Issue
Close #
